### PR TITLE
Update dependency on google_drive gem

### DIFF
--- a/roo-google.gemspec
+++ b/roo-google.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "roo", ">= 2.0.0beta1", "< 3"
-  spec.add_dependency "google_drive", '~> 1'
+  spec.add_dependency "roo", ">= 2.0", "< 3"
+  spec.add_dependency "google_drive", '~> 2'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We recently upgraded google-api-client to 0.13.1 and this created a bit of a tangle in our dependencies.

google_drive 1.0.6 depends on google-api-client < 0.9. So, upgrading google-api-client to 0.13 requires us to bump google_drive to 2.0

Unfortunately, roo-google depends on google_drive < 2.0. This means that roo-google is incompatible with google-api-client > 0.9

I updated the dependency but unfortunately do not have permission to re-record any of the tests. So I'm not entirely sure this is a straigt upgrade although, from what I've read, it should be smooth.